### PR TITLE
The U8 Archive Update

### DIFF
--- a/cmd/arc/extract.go
+++ b/cmd/arc/extract.go
@@ -1,0 +1,68 @@
+package arc
+
+import (
+	"errors"
+	"fmt"
+	"github.com/urfave/cli/v2"
+	"github.com/wii-tools/arclib"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func Extract(c *cli.Context) error{
+	// Create an empty U8 archive
+	arc := arclib.ARC{}
+
+	err := arc.LoadFromFile(c.String("in"))
+	if err != nil {
+		return err
+	}
+
+	// Create output directory if already not existing
+	out := c.String("out")
+	err = os.Mkdir(out, 0755)
+	if os.IsExist(err) {
+		// Check if this is a file.
+		// We are okay with overwriting existing files within folders.
+		stat, err := os.Stat(out)
+		if err != nil {
+			return err
+		}
+
+		if !stat.IsDir() {
+			return errors.New(fmt.Sprintf("%s is not a directory", out))
+		}
+	} else if err != nil {
+		// This isn't an error we know how to cope with.
+		return err
+	}
+
+
+	for _, file := range arc.Contents() {
+		data, err := arc.Read(file)
+		if err != nil {
+			return err
+		}
+
+		path := filepath.Join(out, file)
+		last := strings.LastIndex(path, "/")
+		mkdirPath := path[:last]
+
+		err = os.MkdirAll(mkdirPath, 0700)
+		if os.IsExist(err) {
+			// We need to continue to create other parent directories
+			continue
+		}
+
+		err = ioutil.WriteFile(path, data, 0777)
+		if err != nil {
+			return err
+		}
+	}
+
+	fmt.Fprint(c.App.Writer, "Successfully extracted U8 archive!\n")
+
+	return nil
+}

--- a/cmd/arc/inspect.go
+++ b/cmd/arc/inspect.go
@@ -1,0 +1,31 @@
+package arc
+
+import (
+	"fmt"
+	"github.com/urfave/cli/v2"
+	"github.com/wii-tools/arclib"
+)
+
+func Inspect(c *cli.Context) error{
+	// Create an empty U8 Archive
+	arc := arclib.ARC{}
+
+	err := arc.LoadFromFile(c.String("in"))
+	if err != nil {
+		return err
+	}
+
+	data := arc.Contents()
+	num := len(data)
+
+	fmt.Fprintf(c.App.Writer, "There are %d files in this U8 archive.\n\n", num)
+	for _, contents := range data{
+		size, err := arc.Read(contents)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(c.App.Writer, "File Path: %s | Size: %d\n",  contents, len(size))
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.15
 
 require (
 	github.com/urfave/cli/v2 v2.2.0
+	github.com/wii-tools/arclib v0.0.0-20201001135538-6de73da4ab64
 	github.com/wii-tools/wadlib v0.2.1
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5I
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/urfave/cli/v2 v2.2.0 h1:JTTnM6wKzdA0Jqodd966MVj4vWbbquZykeX1sKbe2C4=
 github.com/urfave/cli/v2 v2.2.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
+github.com/wii-tools/arclib v0.0.0-20201001135538-6de73da4ab64 h1:4vqze8eoiU+koO+wpOLl5jT/zUx8HK/pxGSo8M0epPQ=
+github.com/wii-tools/arclib v0.0.0-20201001135538-6de73da4ab64/go.mod h1:iEWYSq77U3FSalG65t8sWOC4mp3mgq7mUqW+71bp8cM=
 github.com/wii-tools/wadlib v0.2.1 h1:ns7PbWEVvpnoPNgUXap0UH2F02dJvEGEo+0QBCqIa8Q=
 github.com/wii-tools/wadlib v0.2.1/go.mod h1:rXjandeA32Lqfs8kU+mqkLeKIgTkhu43NyuiEcgHxwk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/urfave/cli/v2"
+	"github.com/wii-tools/archon/cmd/arc"
 	"github.com/wii-tools/archon/cmd/wad"
 	"log"
 	"os"
@@ -41,6 +42,27 @@ func main() {
 							&cli.StringFlag{Name: "in", Usage: "directory to extract contents to", Required: true},
 							&cli.StringFlag{Name: "out", Usage: "path to output the WAD", Required: true},
 							&cli.BoolFlag{Name: "id", Usage: "read contents by ID, instead of index"},
+						},
+					},
+				},
+			},
+			{
+				Name: "u8",
+				Usage: "U8 archive related operations",
+				Subcommands: []*cli.Command{
+					{
+						Name: "inspect",
+						Action: arc.Inspect,
+						Flags: []cli.Flag{
+							&cli.StringFlag{Name: "in", Usage: "path to the U8 archive", TakesFile: true, Required: true},
+						},
+					},
+					{
+						Name: "extract",
+						Action: arc.Extract,
+						Flags: []cli.Flag{
+							&cli.StringFlag{Name: "in", Usage: "path to the U8 archive", TakesFile: true, Required: true},
+							&cli.StringFlag{Name: "out", Usage: "path to where you want to extract", Required: true},
 						},
 					},
 				},


### PR DESCRIPTION
I integrated arclib, so now you can extract all the contents of an U8 archive to a specific directory, as well as an `inspect` command, which lists all the files in the archive, their sizes and the number of files in the archive.